### PR TITLE
Add S3 key index

### DIFF
--- a/flashflood/key_index.py
+++ b/flashflood/key_index.py
@@ -1,0 +1,63 @@
+import io
+import typing
+
+from flashflood.util import delete_keys
+
+class BaseKeyIndex:
+    """
+    Build a simple key value index using s3 keys. Updates are modeled as writes to avoid S3 eventual consistency for
+    overwrites.
+
+    Concurrent writes are not supported.
+    """
+    DELIMITER: str = "--"
+    bucket: typing.Any = None
+    _pfx: typing.Optional[str] = None
+
+    @classmethod
+    def put(cls, lookup: str, target: str):
+        keys = cls._put(lookup, target)
+        delete_keys(cls.bucket, keys)
+
+    @classmethod
+    def put_batch(cls, lookup_map: dict):
+        keys_to_delete = list()
+        for lookup, target in lookup_map.items():
+            keys = cls._put(lookup, target)
+            keys_to_delete.extend(keys)
+        delete_keys(cls.bucket, keys_to_delete)
+
+    @classmethod
+    def _put(cls, lookup: str, target: str) -> list:
+        keys = cls._lookup_keys(lookup)
+        if keys:
+            revision_number = cls._revision_number_for_key(keys[-1]) + 1
+        else:
+            revision_number = 1
+        revision = "%010i" % revision_number
+        key = f"{cls._pfx}/{lookup}" + cls.DELIMITER + revision
+        cls.bucket.Object(key).upload_fileobj(io.BytesIO(b""),
+                                              ExtraArgs=dict(Metadata=dict(target=target)))
+        return keys
+
+    @classmethod
+    def delete(cls, lookup: str):
+        keys = cls._lookup_keys(lookup)
+        if keys:
+            delete_keys(cls.bucket, keys)
+
+    @classmethod
+    def get(cls, lookup: str):
+        keys = cls._lookup_keys(lookup)
+        if keys:
+            return cls.bucket.Object(keys[-1]).metadata['target']
+        else:
+            return None
+
+    @classmethod
+    def _lookup_keys(cls, lookup: str):
+        return [item.key for item in cls.bucket.objects.filter(Prefix=f"{cls._pfx}/{lookup}")]
+
+    @classmethod
+    def _revision_number_for_key(cls, key: str) -> int:
+        return int(key.rsplit(cls.DELIMITER, 1)[1])

--- a/tests/test_key_index.py
+++ b/tests/test_key_index.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import io
+import os
+import sys
+import time
+import typing
+from uuid import uuid4
+import unittest
+
+import boto3
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from flashflood.key_index import BaseKeyIndex
+from flashflood.util import concurrent_listing, delete_keys
+from tests import infra
+
+
+class TestKeyIndex(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.root_pfx = f"flashflood-test-key-index-{uuid4()}"
+        cls.s3 = boto3.resource("s3")
+        cls.bucket = cls.s3.Bucket(infra.get_env("S3_BUCKET"))
+
+    @classmethod
+    def tearDownClass(cls):
+        keys_to_delete = [item.key for item in concurrent_listing(cls.bucket, [f"{cls.root_pfx}/"])]
+        delete_keys(cls.bucket, keys_to_delete)
+
+    def setUp(self):
+        class KeyIndex(BaseKeyIndex):
+            bucket = self.bucket
+            _index_pfx = self.root_pfx
+
+        self.index = KeyIndex
+
+    def test_key_index_put(self):
+        self.index.put("foo", "bar")
+        self.assertEqual(self.index.get("foo"), "bar")
+
+    def test_key_index_put_batch(self):
+        items = {str(uuid4()): str(uuid4()) for _ in range(10)}
+        self.index.put_batch(items)
+        for key, val in items.items():
+            self.assertEqual(self.index.get(key), val)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Utility class for managing a simple key-value index on top of s3.

This will be used in the flash-flood refactor.