### PR TITLE
Make base s3 client available to flashflood objects

### DIFF
--- a/flashflood/objects.py
+++ b/flashflood/objects.py
@@ -21,11 +21,14 @@ class Event(typing.NamedTuple):
 
 class BaseJournalUpdate:
     bucket: typing.Any = None
+    s3_client: typing.Any = None
     _pfx: typing.Optional[str] = None
 
     def __init__(self, update_id: JournalUpdateID):
         self.id_ = update_id
         self._data: typing.Optional[bytes] = None
+        assert self.s3_client
+        assert self._pfx
 
     @classmethod
     def make(cls, journal_id: JournalID, event_id: str, action: JournalUpdateAction):
@@ -134,6 +137,7 @@ class BaseJournalUpdate:
 
 class BaseJournal:
     bucket: typing.Any = None
+    s3_client: typing.Any = None
     _journal_pfx: typing.Optional[str] = None
     _blobs_pfx: typing.Optional[str] = None
 
@@ -144,6 +148,9 @@ class BaseJournal:
         self._body: typing.Optional[typing.BinaryIO] = None
         self._location = "memory"
         self.version = version or timestamp_now()
+        assert self.s3_client
+        assert self._journal_pfx
+        assert self._blobs_pfx
 
     @classmethod
     def from_key(cls, key: str):

--- a/tests/test_flashflood.py
+++ b/tests/test_flashflood.py
@@ -152,7 +152,7 @@ class TestFlashFlood(unittest.TestCase):
                         del expected_events[event.event_id]
             if not expected_events:
                 return
-            time.sleep(0.5)
+            time.sleep(1.0)
         self.fail("Expected events did not appear correctly in event replay")
 
     def _test_update(self, events, number_of_updates=2, number_of_events_to_journal=0):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -33,11 +33,13 @@ class TestObjects(unittest.TestCase):
 
         class Journal(BaseJournal):
             bucket = cls.bucket
+            s3_client = cls.s3.meta.client
             _journal_pfx = f"{cls.root_pfx}/journals"
-            _blob_pfx = f"{cls.root_pfx}/blobs"
+            _blobs_pfx = f"{cls.root_pfx}/blobs"
 
         class JournalUpdate(BaseJournalUpdate):
             bucket = cls.bucket
+            s3_client = cls.s3.meta.client
             _pfx = f"{cls.root_pfx}/updates"
 
         cls.Journal = Journal
@@ -178,8 +180,9 @@ class TestObjects(unittest.TestCase):
 
         class Journal(BaseJournal):
             bucket = self.bucket
+            s3_client = self.Journal.s3_client
             _journal_pfx = pfx
-            _blob_pfx = self.Journal._blob_pfx
+            _blobs_pfx = self.Journal._blobs_pfx
 
         with self.subTest("Test listing all Journals"):
             expected_ids = sorted(latest_journal_ids.values())
@@ -202,6 +205,7 @@ class TestObjects(unittest.TestCase):
     def test_list_journal_updates(self):
         class JournalUpdate(BaseJournalUpdate):
             bucket = self.bucket
+            s3_client = self.Journal.s3_client
             _pfx = f"{self.root_pfx}/test_list_updates"
 
         living_updates, _ = self._generate_and_upload_test_updates(JournalUpdate._pfx)


### PR DESCRIPTION
This will be used later to add object tagging to 

Also add assert expectations for basic object attributes.