### PR TITLE
Add s3 upload utility

### DIFF
--- a/flashflood/config.py
+++ b/flashflood/config.py
@@ -1,0 +1,1 @@
+object_exists_waiter_config = dict(Delay=0, MaxAttempts=5)


### PR DESCRIPTION
This adds a utility method to upload objects to s3, with optional configuration to wait for s3 consistency. This functionality will be useful to prevent flakiness in the test suite due to s3 consistency.